### PR TITLE
Add supportedTlds() to list Service's supported TLDs

### DIFF
--- a/example.php
+++ b/example.php
@@ -25,6 +25,19 @@ $service = new DomainAvailability($whoisClient, $dataLoader);
         <input type="submit" value="Go">
     </form>
 
+    <form style="margin: 10px;" action="" method="get">
+        <input type="text" name="tld" id="tld" value="list" hidden>
+        <input type="submit" value="List All TLDs">
+    </form>
+
+    <?php if (isset($_GET["tld"]) && $_GET["tld"] == "list" ) : ?>
+        <ul>
+            <?php foreach ($service->supportedTlds() as $tld) : ?>
+                <li><?= $tld; ?></li>
+            <?php endforeach; ?>
+        </ul>
+    <?php endif; ?>
+
     <table border="1" cellpadding="5">
         <tr>
             <td>Status</td>

--- a/src/Service/DomainAvailability.php
+++ b/src/Service/DomainAvailability.php
@@ -83,6 +83,17 @@ class DomainAvailability
     }
 
 
+
+    /**
+     * Returns an array of all TLDs supported by the service.
+     */
+    public function supportedTlds()
+    {
+        return array_keys($this->servers);
+    }
+
+
+
     /**
      * Wrapper around Jeremy Kendall's PHP Domain Parser that parses the
      * domain/url passed to the function and returns the Tld and Valid domain


### PR DESCRIPTION
Returns a list of supported TLDs in the DomainAvailabilty service. Adds the enhancement discussed in issue #14.

Also adds a button in example.php for demonstration purposes.