### PR TITLE
Fix wrong not-found message for .be extension

### DIFF
--- a/src/data/servers.json
+++ b/src/data/servers.json
@@ -109,7 +109,7 @@
   },
   "be": {
     "server": "whois.dns.be",
-    "not_found": "Status: AVAILABLE"
+    "not_found": "Status:\tAVAILABLE\r\n"
   },
   "berlin": {
     "server": "whois.nic.berlin",


### PR DESCRIPTION
I fixed the `not-found` message for `.be` extension.

I remain available if there is some changes to do.
Then can you make a new release tag (`0.2.4` ?) ?

Thanks,
Regards.