### PR TITLE
Added site tld whois server support

### DIFF
--- a/src/data/servers.json
+++ b/src/data/servers.json
@@ -1083,6 +1083,10 @@
     "server": "whois.arnes.si",
     "not_found": "No entries found"
   },
+  "site": {
+    "server": "whois.nic.site",
+    "not_found": "DOMAIN NOT FOUND"
+  },
   "singles": {
     "server": "whois.donuts.co",
     "not_found": "Domain not found."


### PR DESCRIPTION
```bash
$ whois -h whois.nic.site thisdomaindoesnotexist.site
The queried object does not exist: DOMAIN NOT FOUND

>>> Last update of WHOIS database: 2018-11-19T23:06:00.0Z <<<

For more information on Whois status codes, please visit https://icann.org/epp

This whois service is provided by CentralNic Ltd and only contains
information pertaining to Internet domain names registered by our
our customers. By using this service you are agreeing (1) not to use any
information presented here for any purpose other than determining
ownership of domain names, (2) not to store or reproduce this data in
any way, (3) not to use any high-volume, automated, electronic processes
to obtain data from this service. Abuse of this service is monitored and
actions in contravention of these terms will result in being permanently
blacklisted. All data is (c) CentralNic Ltd https://www.centralnic.com/

Access to the whois service is rate limited. For more information, please
see https://registrar-console.centralnic.com/pub/whois_guidance.
```