### PR TITLE
Fixed ws tld whois server not found match

### DIFF
--- a/src/data/servers.json
+++ b/src/data/servers.json
@@ -1389,7 +1389,7 @@
   },
   "ws": {
     "server": "whois.website.ws",
-    "not_found": "No match for"
+    "not_found": "The queried object does not exist"
   },
   "xxx": {
     "server": "whois.nic.xxx",


### PR DESCRIPTION
```bash
$ whois -h whois.website.ws thisdomaindoesnotexist.ws
The queried object does not exist: thisdomaindoesnotexist.ws.
URL of the ICANN WHOIS Data Problem Reporting System: http://wdprs.internic.net/
>>> Last update of WHOIS database: 2019-02-24T13:53:54Z <<<

For more information on Whois status codes, please visit https://icann.org/epp
```

Fixes issue #33 