### PR TITLE
Fixed the not-found test string for .IO domains

### DIFF
--- a/src/data/servers.json
+++ b/src/data/servers.json
@@ -13,7 +13,7 @@
   },
   "io": {
     "server": "whois.nic.io",
-    "not_found": "is available for purchase"
+    "not_found": "NOT FOUND"
   },
   "computer": {
     "server": "whois.donuts.co",


### PR DESCRIPTION
The test string 'is available for purchase' must be changed. Responses from [whois.nic.io](http://whois.nic.io/) contains 'NOT FOUND' for domains that have not been found.