### PR TITLE
Added a positive test for more certainty

### DIFF
--- a/src/Service/DomainAvailability.php
+++ b/src/Service/DomainAvailability.php
@@ -23,6 +23,14 @@ class DomainAvailability
     }
 
 
+    /**
+     * Check if the passed domain is available for registrytion.
+     *
+     * @param string $domain    The domain that should be checked.
+     * @param bool $quick       If TRUE the domain is considered as NOT available if there exists a DNS record.
+     * @throws \Exception       Exception is thrown if the domain status is not clear.
+     * @return bool
+     */
     public function isAvailable($domain, $quick = false)
     {
 
@@ -76,10 +84,11 @@ class DomainAvailability
         if (strpos($whoisData, $whoisServerInfo["not_found"]) !== false) {
             // The domain is available
             return true;
+        } else if (!isset($whoisServerInfo["found"]) || strpos($whoisData, $whoisServerInfo["found"]) !== false) {
+            // If we've come this far, the domain is not available.
+            return false;
         }
-
-        // If we've come this far, the domain is not available.
-        return false;
+        throw new \Exception('The domain registration status is not clear.');
     }
 
 

--- a/src/data/servers.json
+++ b/src/data/servers.json
@@ -1,31 +1,38 @@
 {
   "com": {
     "server": "whois.verisign-grs.com",
-    "not_found": "No match for "
+    "not_found": "No match for ",
+    "found": "Registry Domain ID:"
   },
   "net": {
     "server": "whois.verisign-grs.com",
-    "not_found": "No match for "
+    "not_found": "No match for ",
+    "found": "Registry Domain ID:"
   },
   "org": {
     "server": "whois.pir.org",
-    "not_found": "NOT FOUND"
+    "not_found": "NOT FOUND",
+    "found": "Registry Domain ID:"
   },
   "io": {
     "server": "whois.nic.io",
-    "not_found": "NOT FOUND"
+    "not_found": "is available for purchase",
+    "found": "Registry Domain ID:"
   },
   "computer": {
     "server": "whois.donuts.co",
-    "not_found": "Domain not found."
+    "not_found": "Domain not found.",
+    "found": "Creation Date:"
   },
   "ac": {
     "server": "whois.nic.ac",
-    "not_found": "is available for purchase"
+    "not_found": "is available for purchase",
+    "found": "Creation Date:"
   },
   "academy": {
     "server": "whois.donuts.co",
-    "not_found": "Domain not found."
+    "not_found": "Domain not found.",
+    "found": "Creation Date:"
   },
   "actor": {
     "server": "whois.unitedtld.com",
@@ -333,7 +340,8 @@
   },
   "de": {
     "server": "whois.denic.de",
-    "not_found": "Status: free"
+    "not_found": "Status: free",
+    "found": "Status: connect"
   },
   "democrat": {
     "server": "whois.unitedtld.com",
@@ -469,7 +477,8 @@
   },
   "fr": {
     "server": "whois.nic.fr",
-    "not_found": "No entries found"
+    "not_found": "No entries found",
+    "found": "Expiry Date"
   },
   "frogans": {
     "server": "whois-frogans.nic.fr",
@@ -1405,7 +1414,8 @@
   },
   "ws": {
     "server": "whois.website.ws",
-    "not_found": "The queried object does not exist"
+    "not_found": "The queried object does not exist",
+    "found": "Creation Date:"
   },
   "xxx": {
     "server": "whois.nic.xxx",


### PR DESCRIPTION
As I have suggested in #51 I have created this PR which adds an additional test to be sure that a given domain was really found.

This check is only done if the TLD entry in the servers.json has an entry for the key `found`.

Here's an example:
```json
  "io": {
    "server": "whois.nic.io",
    "not_found": "NOT FOUND",
    "found": "Registry Domain ID"
  },
```

if the response of the whois server does not contain "NOT FOUND" the domain is not directly considered as *registered*, but there is done a further check for the string "Registry Domain ID". If this string is found, the domain is considered as *registered* or *not available*.

I have also added the "found" key to several tld entries. But not for all. For those entries that do not have this property, the previous behaviour is kept.