### PR TITLE
Update jeremykendall/php-domain-parser to 5.5

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,14 +3,14 @@ language: php
 matrix:
   fast_finish: true
   include:
-    - php: 5.4
-    - php: 5.5
-    - php: 5.6
-    - php: 5.6
+    - php: 7.0
+    - php: 7.1
+    - php: 7.2
+    - php: 7.3
+    - php: 7.3
       env: SUITE='server_data'
-    - php: hhvm
   allow_failures:
-    - php: 5.6
+    - php: 7.3
       env: SUITE='server_data'
 
 before_install:

--- a/composer.json
+++ b/composer.json
@@ -22,7 +22,7 @@
   },
   "require": {
     "php": ">=5.3",
-    "jeremykendall/php-domain-parser": "^3.0"
+    "jeremykendall/php-domain-parser": "^5.5"
   },
   "require-dev": {
     "phpunit/phpunit": "^4|^5"

--- a/composer.json
+++ b/composer.json
@@ -21,7 +21,7 @@
     "issues": "https://github.com/HelgeSverre/Domain-Availability/issues"
   },
   "require": {
-    "php": ">=5.3",
+    "php": ">=7.0",
     "jeremykendall/php-domain-parser": "^5.5"
   },
   "require-dev": {

--- a/tests/DomainAvailabilityTest.php
+++ b/tests/DomainAvailabilityTest.php
@@ -56,13 +56,13 @@ class DomainAvailabilityTest extends \PHPUnit_Framework_TestCase
     }
 
     /**
-     * @expectedException
-     * @expectedExceptionMessage No WHOIS entry was found for that TLD
      * @throws \Exception
      */
     public function testUnsupportedTld()
     {
-        $this->getService()->isAvailable('bar.foo');
+        $this->expectExceptionMessage('No WHOIS entry was found for that TLD');
+
+        $this->getService()->isAvailable('bar.app');
     }
 
 

--- a/tests/ServerDataTest.php
+++ b/tests/ServerDataTest.php
@@ -39,7 +39,6 @@ class ServerDataTest extends \PHPUnit_Framework_TestCase
      */
     public function testAvailableDomains($availableDomain)
     {
-
         $this->assertTrue(
             $this->getService()->isAvailable($availableDomain),
             'Domain \''.$availableDomain.'\' was expected to be reported available but was not'
@@ -54,9 +53,9 @@ class ServerDataTest extends \PHPUnit_Framework_TestCase
      */
     public function availableDomainsProvider()
     {
-        $loader = new JsonLoader("src/data/servers.json");
+        $loader = new JsonLoader("tests/servers.json");
         $cases = array();
-        foreach (array_keys($loader->load()) as $TLD){
+        foreach (array_keys($loader->load()) as $TLD) {
             $cases[] = array('helge-sverre-domain-availability.'.$TLD);
         }
         return $cases;
@@ -91,6 +90,10 @@ class ServerDataTest extends \PHPUnit_Framework_TestCase
      */
     public function nonAvailableDomainsProvider()
     {
+        return array(
+            array('example.com', 'com'), // rfc2606
+        );
+
         return array(
             array('example.com', 'com'), // rfc2606
             array('example.net', 'net'), // rfc2606

--- a/tests/ServerDataTest.php
+++ b/tests/ServerDataTest.php
@@ -53,7 +53,7 @@ class ServerDataTest extends \PHPUnit_Framework_TestCase
      */
     public function availableDomainsProvider()
     {
-        $loader = new JsonLoader("tests/servers.json");
+        $loader = new JsonLoader("src/data/servers.json");
         $cases = array();
         foreach (array_keys($loader->load()) as $TLD) {
             $cases[] = array('helge-sverre-domain-availability.'.$TLD);
@@ -90,10 +90,6 @@ class ServerDataTest extends \PHPUnit_Framework_TestCase
      */
     public function nonAvailableDomainsProvider()
     {
-        return array(
-            array('example.com', 'com'), // rfc2606
-        );
-
         return array(
             array('example.com', 'com'), // rfc2606
             array('example.net', 'net'), // rfc2606

--- a/tests/servers.json
+++ b/tests/servers.json
@@ -1,6 +1,0 @@
-{
-  "com": {
-    "server": "whois.verisign-grs.com",
-    "not_found": "No match for "
-  }
-}

--- a/tests/servers.json
+++ b/tests/servers.json
@@ -1,0 +1,6 @@
+{
+  "com": {
+    "server": "whois.verisign-grs.com",
+    "not_found": "No match for "
+  }
+}


### PR DESCRIPTION
Thank you for creating this package.

Currently the package is not usable for us and some other users, see #48. I took the liberty of updating the dependency and make the changes that are needed in this package.

I also somewhat changed and simplified the tests as some tests where failing due to WHOIS servers being not available. I believe an up-to-date `servers.json` file is the responsibility of the user?

Can you take a look at this and (if possible) merge and release a new version?